### PR TITLE
Upgrading to debian stretch with libsrtp update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 ############################################################
-# Dockerfile - Janus Gateway on Debian Jessie
+# Dockerfile - Janus Gateway on Debian Stretch
 # https://github.com/krull/docker-janus
 ############################################################
 
 # set base image debian jessie
-FROM debian:jessie
+FROM debian:stretch
 
 # file maintainer author
 MAINTAINER brendan jocson <brendan@jocson.eu>
@@ -39,6 +39,7 @@ ARG JANUS_BUILD_DEPS_DEV="\
     libglib2.0-dev \
     libopus-dev \
     libogg-dev \
+    liblua5.3-dev \
     pkg-config \
     "
 ARG JANUS_BUILD_DEPS_EXT="\
@@ -82,9 +83,9 @@ RUN \
     && DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install $JANUS_BUILD_DEPS_DEV ${JANUS_BUILD_DEPS_EXT} \
 # build libsrtp
-    && curl -fSL https://github.com/cisco/libsrtp/archive/v2.0.0.tar.gz -o ${BUILD_SRC}/v2.0.0.tar.gz \
-    && tar xzf ${BUILD_SRC}/v2.0.0.tar.gz -C ${BUILD_SRC} \
-    && cd ${BUILD_SRC}/libsrtp-2.0.0 \
+    && curl -fSL https://github.com/cisco/libsrtp/archive/v2.1.0.tar.gz -o ${BUILD_SRC}/v2.1.0.tar.gz \
+    && tar xzf ${BUILD_SRC}/v2.1.0.tar.gz -C ${BUILD_SRC} \
+    && cd ${BUILD_SRC}/libsrtp-2.1.0 \
     && ./configure --prefix=/usr --enable-openssl \
     && make shared_library \
     && make install \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # docker-janus
 `docker-janus` is a Debian 8 based docker image for [Meetecho's Janus Gateway](https://github.com/meetecho/janus-gateway)
+`docker-janus` is a Debian 9 based docker image for [Meetecho's Janus Gateway](https://github.com/meetecho/janus-gateway)
 
 ## Description
 All the janus docker builds I have seen in hub.docker.com were all ubuntu based and/or of some redhat flavor. I successfully build janus in debian 7 and 8 before, so I thought it would be a good way to practice docker best practices and provide a debian based image at the same time.


### PR DESCRIPTION
I had problems with Chrome 66 and Jessie's libnice 0.1.7.

Upgrading the docker image to a Debian Stretch which is on libnice 0.1.13 right now.
Also upgrading to libsrtp 2.1.0 in order to compile properly.

Enjoy!